### PR TITLE
feature: blank page navigate to login page

### DIFF
--- a/frontend/src/routes/protected.route.tsx
+++ b/frontend/src/routes/protected.route.tsx
@@ -1,0 +1,21 @@
+import { useAppSelector } from "@/store/hooks";
+import React from "react";
+import { Navigate, Route, Routes, useLocation } from "react-router-dom";
+
+type RouteProps = {
+  path: string;
+  children: React.ReactNode;
+};
+const ProtectedRoute = ({ path, children }: RouteProps) => {
+  const { isLoggedIn } = useAppSelector((state) => state.auth);
+  let location = useLocation();
+  return isLoggedIn ? (
+    <Routes>
+      <Route path={path}>{children}</Route>
+    </Routes>
+  ) : (
+    <Navigate to={"/"} state={{ from: location }} replace={true} />
+  );
+};
+
+export default ProtectedRoute;

--- a/frontend/src/routes/root.route.tsx
+++ b/frontend/src/routes/root.route.tsx
@@ -1,7 +1,6 @@
 import {
   ForgotPassword,
   Login,
-  NameEntry,
   QuestionandAnswer,
   Register,
   SelectCategory,
@@ -12,7 +11,7 @@ import { ROUTES } from "@/routes";
 export const router = createBrowserRouter([
   {
     path: ROUTES.HOMEPAGE,
-    element: <NameEntry />,
+    element: <Login />,
   },
   {
     path: `${ROUTES.QUESTIOANDANSWER}/:id`,

--- a/frontend/src/routes/root.route.tsx
+++ b/frontend/src/routes/root.route.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/pages";
 import { createBrowserRouter } from "react-router-dom";
 import { ROUTES } from "@/routes";
+import ProtectedRoute from "./protected.route";
 
 export const router = createBrowserRouter([
   {
@@ -15,11 +16,19 @@ export const router = createBrowserRouter([
   },
   {
     path: `${ROUTES.QUESTIOANDANSWER}/:id`,
-    element: <QuestionandAnswer />,
+    element: (
+      <ProtectedRoute path={`/${ROUTES.QUESTIOANDANSWER}/:id`}>
+        <QuestionandAnswer />
+      </ProtectedRoute>
+    ),
   },
   {
     path: ROUTES.SELECTCATEGORY,
-    element: <SelectCategory />,
+    element: (
+      <ProtectedRoute path={`/${ROUTES.SELECTCATEGORY}`}>
+        <SelectCategory />
+      </ProtectedRoute>
+    ),
   },
   {
     path: ROUTES.LOGIN,


### PR DESCRIPTION
## Description

Remove the NameEntry page and set the Login page in the blank route.
When the user opens an app it redirects to the login page.

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

If applicable, add screenshots to help explain your changes.

## Additional Notes

Add any other context or screenshots about the pull request here.
